### PR TITLE
fixed desktop remove on closing maximized window

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -356,12 +356,14 @@ Main.prototype.moveBack = function(client, removed) {
 Main.prototype.install = function() {
     workspace.clientFullScreenSet.connect(this.handlers.fullscreen);
     workspace.clientMaximizeSet.connect(this.handlers.maximize);
+    workspace.clientRemoved.connect(this.handlers.closed);
     log("Handler installed");
 }
 
 Main.prototype.uninstall = function() {
     workspace.clientFullScreenSet.disconnect(this.handlers.fullscreen);
     workspace.clientMaximizeSet.disconnect(this.handlers.maximize);
+    workspace.clientRemoved.disconnect(this.handlers.closed);
     log("Handler cleared");
 }
 


### PR DESCRIPTION
If you close a maximized window, the virtual desktop does not get removed. Upon debugging I figured that in 'closed' hook on line 181 in main.js, client object is None type. I fixed it by hooking the closed handler with workspace.clientRemoved in install and uninstall function.