### PR TITLE
prevent switching to new desktop when `Kickerdash` openned if it's on `Latte Dock`'s panel

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -21,7 +21,7 @@ const NewDesktopPositionValue = {
 /**
  * Clients that should skipped always
  */
-const GlobalSkippedClients = ['ksmserver-logout-greeter', 'plasmashell'];
+const GlobalSkippedClients = ['ksmserver-logout-greeter', 'plasmashell', 'latte-dock', 'lattedock'];
 
 function Config() {
 }


### PR DESCRIPTION
If you use Latte Dock and place `Kickerdash` (the dashboard style application launcher) applet on the panel, when you open the application dashboard, this script will switch to a new desktop.
I think this behaviour should be avoid. So, fixed  it in this commit.